### PR TITLE
Modify the def write_before to write_video as write_video fails

### DIFF
--- a/docs/recipes2.rst
+++ b/docs/recipes2.rst
@@ -614,7 +614,7 @@ to the in-memory ring-buffer::
             prior_image = current_image
             return result
 
-    def write_before(stream):
+    def write_video(stream):
         # Write the entire content of the circular buffer to disk. No need to
         # lock the stream here as we're definitely not writing to it
         # simultaneously


### PR DESCRIPTION
I think there is a minor typo in the last example when motion is found. Modified the def from write_before to write_video.
