### PR TITLE
Fix for issue #175

### DIFF
--- a/picamera/streams.py
+++ b/picamera/streams.py
@@ -447,7 +447,7 @@ class PiCameraCircularIO(CircularIO):
             size = bitrate * seconds // 8
         super(PiCameraCircularIO, self).__init__(size)
         self.camera = camera
-        self._data = PiCameraDequeHack(camera)
+        self._data = PiCameraDequeHack(camera, splitter_port)
 
     @property
     def frames(self):


### PR DESCRIPTION
Pass splitter_port as an argument to PiCameraDequeHack in the constructor of PiCameraCircularIO. This argument was previously ignored.
