### PR TITLE
Improves MJPEG video encoding

### DIFF
--- a/picamera/encoders.py
+++ b/picamera/encoders.py
@@ -462,7 +462,14 @@ class PiEncoder(object):
         mmal.mmal_format_copy(
             self.output_port[0].format, self.encoder[0].input[0][0].format)
         # Set buffer size and number to appropriate values
-        self.output_port[0].buffer_size = self.output_port[0].buffer_size_recommended
+        if self.format == 'mjpeg':
+            # There is a bug in the MJPEG encoder that causes a deadlock if the FIFO
+            # is full on shutdown. Increasing the encoder buffer size makes this
+            # less likely to happen.
+            # See https://github.com/raspberrypi/userland/issues/208
+            self.output_port[0].buffer_size = 512 * 1024
+        else:
+            self.output_port[0].buffer_size = self.output_port[0].buffer_size_recommended
         self.output_port[0].buffer_num = self.output_port[0].buffer_num_recommended
         # NOTE: We deliberately don't commit the output port format here as
         # this is a base class and the output configuration is incomplete at


### PR DESCRIPTION
As discussed in https://github.com/raspberrypi/userland/issues/208, the MJPEG encoder may deadlock
if the FIFO is full on shutdown. This change increases the encoder buffer size,
which helps to keep the FIFO size down.

With this change, the following program exits cleanly. Previously, it would
lock up the camera, requiring a reboot.

import picamera
import time

camera = picamera.PiCamera()
camera.resolution = (1296, 972)
camera.framerate = 15

camera.start_recording('test.mjpeg', format='mjpeg', quality=0)
time.sleep(5)
camera.stop_recording()
