### PR TITLE
tentative fix for bug #218

### DIFF
--- a/picamera/camera.py
+++ b/picamera/camera.py
@@ -531,15 +531,17 @@ class PiCamera(object):
         if not self._camera[0].output_num:
             raise PiCameraError("Camera doesn't have output ports")
 
-        mp = mmal.MMAL_PARAMETER_INT32_T(
-            mmal.MMAL_PARAMETER_HEADER_T(
-                mmal.MMAL_PARAMETER_CAMERA_NUM,
-                ct.sizeof(mmal.MMAL_PARAMETER_INT32_T)
-            ),
-            num)
-        mmal_check(
-            mmal.mmal_port_parameter_set(self._camera[0].control, mp.hdr),
-            prefix="Unable to select camera %d" % num)
+       # Don't set up camera number if asked for stereo-mode
+        if stereo_mode == mmal.MMAL_STEREOSCOPIC_MODE_NONE:
+            mp = mmal.MMAL_PARAMETER_INT32_T(
+                mmal.MMAL_PARAMETER_HEADER_T(
+                    mmal.MMAL_PARAMETER_CAMERA_NUM,
+                    ct.sizeof(mmal.MMAL_PARAMETER_INT32_T)
+                ),
+                num)
+            mmal_check(
+                mmal.mmal_port_parameter_set(self._camera[0].control, mp.hdr),
+                prefix="Unable to select camera %d" % num)
 
         if sensor_mode != 0:
             # Don't set sensor mode if 0 is selected, to support older


### PR DESCRIPTION
Following 6by9 comment I came up with this solution that fixes the issue for the stereo mode. Now I can access synchronized streams on my compute module.

Maybe the stereo part of the documentation could be made clearer. Especially this part :
> If the stereo_decimate parameter is True, the resolution of the two cameras will be halved so that the resulting image has the same dimensions as if stereoscopic mode were not being used.

The resolution of the image we get from stereoscopic mode is the same as the given (or default) resolution parameter, and if a regular 4/3 ratio is given, the two images will be halved so that their combination fits into a 4/3 image.

For example, to get one stereo image with two *full* (480x320) images inside, I have to use something like this :
```
camera = picamera.PiCamera(stereo_mode='side-by-side', resolution=(960,320), stereo_decimate=False)
```

