### PR TITLE
rgb_array bug: wrap arround of uint8

### DIFF
--- a/picamera/array.py
+++ b/picamera/array.py
@@ -341,6 +341,7 @@ class PiYUVArray(PiArrayOutput):
     def flush(self):
         super(PiYUVArray, self).flush()
         self.array = bytes_to_yuv(self.getvalue(), self.size or self.camera.resolution)
+        self._rgb = None
 
     @property
     def rgb_array(self):

--- a/picamera/array.py
+++ b/picamera/array.py
@@ -346,7 +346,7 @@ class PiYUVArray(PiArrayOutput):
     def rgb_array(self):
         if self._rgb is None:
             # Apply the standard biases
-            YUV = self.array.copy()
+            YUV = self.array.astype(float)
             YUV[:, :, 0]  = YUV[:, :, 0]  - 16  # Offset Y by 16
             YUV[:, :, 1:] = YUV[:, :, 1:] - 128 # Offset UV by 128
             # YUV conversion matrix from ITU-R BT.601 version (SDTV)


### PR DESCRIPTION
enforce the cast to float before the subtraction (l350, 351)
to avoid wrap-around in the case of low-light images