### PR TITLE
Added pi0 wireless to flash-revisiontable

### DIFF
--- a/docs/recipes2.rst
+++ b/docs/recipes2.rst
@@ -839,6 +839,9 @@ for the revision number if you are unsure):
 | Raspberry Pi Zero rev 1.2 and  | ``/videocore/pins_pi0``    |
 | rev 1.3                        |                            |
 +--------------------------------+----------------------------+
+| Raspberry Pi Zero Wireless     | ``/videocore/pins_pi0w``   |
+| rev 1.1                        |                            |
++--------------------------------+----------------------------+
 
 Under the section for your particular model of Pi you will find ``pin_config``
 and ``pin_defines`` sections. Under the ``pin_config`` section you need to


### PR DESCRIPTION
During experimentation I found out that the Raspberry Pi Zero Wireless does not use the same device-tree as the Raspberry Pi Zero ( [link](https://www.raspberrypi.org/documentation/configuration/pin-configuration.md) ). Hence this pull request adds the option to the revision table in the `add flash` section of the documentation.

Edit: this PR solves issue #390 