### PR TITLE
enable MMALPythonSource to send MJPEG and H264 streams

### DIFF
--- a/docs/examples/mmal_h264_decoder.py
+++ b/docs/examples/mmal_h264_decoder.py
@@ -1,0 +1,44 @@
+from picamera import mmal,mmalobj as mo
+
+source  = mo.MMALPythonSource('test.h264')
+decoder = mo.MMALVideoDecoder()
+preview = mo.MMALRenderer()
+
+# read the input as h264
+source.outputs[0].format = mmal.MMAL_ENCODING_H264
+source.outputs[0].framerate = 25
+source.outputs[0]._format[0].flags = mmal.MMAL_ES_FORMAT_FLAG_FRAMED
+source.outputs[0].framesize = (1280,720)
+source.outputs[0].commit()
+
+# decoder input port
+decoder.inputs[0].copy_from(source.outputs[0])
+decoder.inputs[0].commit()
+
+# decoder output port
+decoder.outputs[0].copy_from(decoder.inputs[0])
+decoder.outputs[0].format = mmal.MMAL_ENCODING_I420
+decoder.outputs[0].commit()
+
+# connect source -> decoder -> preview
+decoder.inputs[0].connect(source.outputs[0])
+decoder.inputs[0].connection.enable()
+preview.inputs[0].connect(decoder.outputs[0])
+
+# enable everything
+preview.enable()
+decoder.enable()
+source.enable()
+
+# start decoding
+try:
+    print "***** start decoding *****"
+    source.wait(15)
+
+finally:
+    print "***** done *****"
+    source.disable()
+    decoder.disable()
+    preview.disable()
+
+

--- a/picamera/mmalobj.py
+++ b/picamera/mmalobj.py
@@ -1,7 +1,7 @@
 # vim: set et sw=4 sts=4 fileencoding=utf-8:
 #
 # Python header conversion
-# Copyright (c) 2013-2015 Dave Jones <dave@waveform.org.uk>
+# Copyright (c) 2013-2017 Dave Jones <dave@waveform.org.uk>
 #
 # Original headers
 # Copyright (c) 2012, Broadcom Europe Ltd

--- a/picamera/mmalobj.py
+++ b/picamera/mmalobj.py
@@ -1,7 +1,7 @@
 # vim: set et sw=4 sts=4 fileencoding=utf-8:
 #
 # Python header conversion
-# Copyright (c) 2013-2017 Dave Jones <dave@waveform.org.uk>
+# Copyright (c) 2013-2015 Dave Jones <dave@waveform.org.uk>
 #
 # Original headers
 # Copyright (c) 2012, Broadcom Europe Ltd
@@ -2592,6 +2592,8 @@ class MMALPythonPort(MMALObject):
 
     _FORMAT_BPP = {
         'I420': 1.5,
+        'H264': 2,
+        'MJPEG': 2,
         'RGB3': 3,
         'RGBA': 4,
         'BGR3': 3,
@@ -2609,6 +2611,8 @@ class MMALPythonPort(MMALObject):
         self._type = port_type
         self._index = index
         self._supported_formats = {
+            mmal.MMAL_ENCODING_H264,
+            mmal.MMAL_ENCODING_MJPEG,
             mmal.MMAL_ENCODING_I420,
             mmal.MMAL_ENCODING_RGB24,
             mmal.MMAL_ENCODING_BGR24,
@@ -2762,7 +2766,7 @@ class MMALPythonPort(MMALObject):
         video = self._format[0].es[0].video
         try:
             self._buffer_size = int(
-                MMALPythonPort._FORMAT_BPP[str(self.format)]
+                MMALPythonPort._FORMAT_BPP[mmal.FOURCC_str(self.format)]
                 * video.width
                 * video.height)
         except KeyError:
@@ -3167,7 +3171,7 @@ class MMALPythonSource(MMALPythonBaseComponent):
         video = self._outputs[0]._format[0].es[0].video
         try:
             framesize = (
-                MMALPythonPort._FORMAT_BPP[str(self._outputs[0].format)]
+                MMALPythonPort._FORMAT_BPP[mmal.FOURCC_str(self._outputs[0].format)]
                 * video.width
                 * video.height)
         except KeyError:
@@ -3191,11 +3195,13 @@ class MMALPythonSource(MMALPythonBaseComponent):
                                 # if there's no readinto() method, fallback on
                                 # read() and the data setter (memmove)
                                 buf.data = self._stream.read(buf.size)
+                                buf.length = len(buf.data)
                         else:
                             buf.data = self._stream.read(send)
+                            buf.length = len(buf.data)
                     if frameleft is not None:
                         frameleft -= buf.length
-                        if not frameleft:
+                        if frameleft <= 0:
                             buf.flags |= mmal.MMAL_BUFFER_HEADER_FLAG_FRAME_END
                             frameleft = framesize
                     if not buf.length:


### PR DESCRIPTION
With this changes I am able to play h264 files with the given example.

There is still an output buffer overrun. (Some channel is missing a 'block=True' probably)
It's to see the bird from the userland test.h264 falling the first time :-)
And very educational to see the effect of missing frames...