### PR TITLE
doc: Slightly zoom property documentation improvement

### DIFF
--- a/docs/fov.rst
+++ b/docs/fov.rst
@@ -527,8 +527,9 @@ recorded. The components that data passes through are as follows:
 
     - **Resizing**: At this point, the frame is resized to the requested output
       resolution (all prior stages have been performed on "full" frame data
-      at whatever resolution the sensor is configured to produce). See
-      :attr:`~PiCamera.resolution`.
+      at whatever resolution the sensor is configured to produce). Firstly, the
+      zoom is applied (see :attr:`~PiCamera.zoom`) and then the image is resized
+      to the requested resolution (see :attr:`~PiCamera.resolution`).
 
    Some of these steps can be controlled directly (e.g. brightness, noise
    reduction), others can only be influenced (e.g. analog and digital gain),

--- a/picamera/camera.py
+++ b/picamera/camera.py
@@ -3422,6 +3422,11 @@ class PiCamera(object):
         the "Region of Interest" or ROI). The default value is ``(0.0, 0.0,
         1.0, 1.0)`` which indicates that everything should be included. The
         property can be set while recordings or previews are in progress.
+
+        The `zoom` is applied to the processed image, after rotation and rescale.
+        If rotation has been used, zoom is composed of ``(y, x, h, w)`` instead.
+        The values `w` and `h` can modify the aspect ratio of the image: use equal
+        values for `w` and `h` if you want to keep the same the aspect ratio. 
         """)
 
     def _get_crop(self):


### PR DESCRIPTION
The docstring of the Picamera.zoom property has been improved explaining the
specific behaviour of this property when it is combined with rotation, for example.
Also, it says that it can modify the aspect ratio of the image.
Moreover, in fov.html documentation, it includes the operation order before retrieving
the processed image: first applies the zoom and then rescale the image.