### PR TITLE
Enhancements for precise A/V sync

### DIFF
--- a/picamera/camera.py
+++ b/picamera/camera.py
@@ -1103,7 +1103,7 @@ class PiCamera(object):
                     'There is no recording in progress on '
                     'port %d' % splitter_port)
         else:
-            encoder.split(output, options.get('motion_output'))
+            return encoder.split(output, options.get('motion_output'))
 
     def request_key_frame(self, splitter_port=1):
         """

--- a/picamera/streams.py
+++ b/picamera/streams.py
@@ -525,23 +525,14 @@ class CircularIO(io.IOBase):
 
 
 class PiCameraDequeHack(deque):
-    def __init__(self, camera, splitter_port=1):
+    def __init__(self, stream):
         super(PiCameraDequeHack, self).__init__()
-        try:
-            camera._encoders
-        except AttributeError:
-            raise PiCameraValueError('camera must be a valid PiCamera object')
-        self.camera = camera
-        self.splitter_port = splitter_port
+        self.stream = stream
 
     def append(self, item):
-        encoder = self.camera._encoders[self.splitter_port]
-        if encoder.frame.complete:
-            # If the chunk being appended is the end of a new frame, include
-            # the frame's metadata from the camera
-            return super(PiCameraDequeHack, self).append((item, encoder.frame))
-        else:
-            return super(PiCameraDequeHack, self).append((item, None))
+        # Include the frame's metadata.
+        frame = self.stream.get_frame()
+        return super(PiCameraDequeHack, self).append((item, frame))
 
     def pop(self):
         return super(PiCameraDequeHack, self).pop()[0]
@@ -673,8 +664,22 @@ class PiCameraCircularIO(CircularIO):
         if seconds is not None:
             size = bitrate * seconds // 8
         super(PiCameraCircularIO, self).__init__(size)
-        self._data = PiCameraDequeHack(camera, splitter_port)
+        try:
+            camera._encoders
+        except AttributeError:
+            raise PiCameraValueError('camera must be a valid PiCamera object')
+        self.camera = camera
+        self.splitter_port = splitter_port
+        self._data = PiCameraDequeHack(self)
         self.frames = PiCameraDequeFrames(self)
+
+    def get_frame(self):
+        """
+        Return frame metadata from latest frame, when it is complete.
+        """
+        encoder = self.camera._encoders[self.splitter_port]
+        frame = encoder.frame
+        return (frame if frame.complete else None)
 
     def clear(self):
         """
@@ -701,22 +706,23 @@ class PiCameraCircularIO(CircularIO):
 
     def _find_seconds(self, seconds, first_frame):
         pos = None
+        prev = None
+        first = None
         last = None
-        seconds = int(seconds * 1000000)
+        if seconds is not None:
+            seconds = int(seconds * 1000000)
         for frame in reversed(self.frames):
             if first_frame in (None, frame.frame_type):
                 pos = frame.position
+                first = prev
             if frame.timestamp is not None:
                 if last is None:
                     last = frame.timestamp
-                elif last - frame.timestamp >= seconds:
+                elif (seconds is not None) and (last - frame.timestamp >= seconds):
                     break
-        return pos
+                prev = frame.timestamp
 
-    def _find_all(self, first_frame):
-        for frame in self.frames:
-            if first_frame in (None, frame.frame_type):
-                return frame.position
+        return (pos, first, last)
 
     def copy_to(
             self, output, size=None, seconds=None,
@@ -760,12 +766,12 @@ class PiCameraCircularIO(CircularIO):
             with self.lock:
                 save_pos = self.tell()
                 try:
+                    start_ts = None
+                    end_ts = None
                     if size is not None:
                         pos = self._find_size(size, first_frame)
-                    elif seconds is not None:
-                        pos = self._find_seconds(seconds, first_frame)
                     else:
-                        pos = self._find_all(first_frame)
+                        (pos, start_ts, end_ts) = self._find_seconds(seconds, first_frame)
                     # Copy chunks efficiently from the position found
                     if pos is not None:
                         self.seek(pos)
@@ -774,6 +780,7 @@ class PiCameraCircularIO(CircularIO):
                             if not buf:
                                 break
                             output.write(buf)
+                    return (start_ts, end_ts)
                 finally:
                     self.seek(save_pos)
         finally:


### PR DESCRIPTION
I've been working on some code that captures audio and attempts to precisely synchronize it with PiCamera video.  I've been having a lot of trouble getting precise control over the number of seconds written by PiCameraCircularIO.copy_to().  This PR attempts to address this issue, and also adds some minor features I've found useful.

The problem is in the handling of frames that are split into multiple chunks (where only the last chunk is marked 'complete').  When chunks are delivered to PiVideoEncoder._callback_write(), only the first chunk of a frame gets a timestamp (I believe this is a hardware behavior).  However, in PiCameraDequeueHack.append(), frame metadata is only saved for the *last* chunk of a frame.  The net result is that split frames never have timestamp data visible to PiCameraCircularIO._find_seconds(), causing it to skip over them.

This PR makes the following changes:
 - PiVideoEncoder._callback_write() replicates the timestamp from the first chunk to all subsequent chunks of a given frame.  This fixes the behavior of _find_seconds().
 - split_recording() now returns the PTS timestamp of the split point.  This is not required to fix the bug, but is useful for precise sync with audio streams.
 - Similarly, copy_to() now returns the start and end timestamp of the data that was written out.
 - Some of the hackiness of PiCameraDequeueHack is moved into PiCameraCircularIO.  Not strictly necessary, but convenient for some other feature additions I'll put in a future PR.