### PR TITLE
Update mmalobj.py

### DIFF
--- a/picamera/mmalobj.py
+++ b/picamera/mmalobj.py
@@ -461,7 +461,7 @@ def buffer_bytes(buf):
     <bufferobjects>`, this function returns the size of the object in bytes.
     The object can be multi-dimensional or include items larger than byte-size.
     """
-    if not isinstance(buf, memoryview):
+    if isinstance(buf, memoryview):
         m = memoryview(buf)
     return m.itemsize * reduce(mul, m.shape)
 


### PR DESCRIPTION
I think there may just be a bug in the statement at line 464, which is
if not isinstance(buf, memoryview):
in release 1.13. If I remove the "not" and put this instead:
if isinstance(buf, memoryview):
it seems to work fine. It was failing when the condition isinstance(buf, memoryview) was true.