### PR TITLE
Fix exception typo in camera module

### DIFF
--- a/picamera/camera.py
+++ b/picamera/camera.py
@@ -1992,7 +1992,7 @@ class PiCamera(object):
         try:
             if buf.command == mmal.MMAL_EVENT_ERROR:
                 raise PiCameraRuntimeError(
-                    "No data recevied from sensor. Check all connections, "
+                    "No data received from sensor. Check all connections, "
                     "including the SUNNY chip on the camera board")
             elif buf.command != mmal.MMAL_EVENT_PARAMETER_CHANGED:
                 raise PiCameraRuntimeError(


### PR DESCRIPTION
It's a harmless PR. Noticed the typo this morning when I played around with various attributes of the PiCamera class.