### PR TITLE
bug fix in bayer_data.py

### DIFF
--- a/docs/examples/bayer_data.py
+++ b/docs/examples/bayer_data.py
@@ -66,7 +66,7 @@ data = data.reshape(reshape)[:crop[0], :crop[1]]
 
 data = data.astype(np.uint16) << 2
 for byte in range(4):
-    data[:, byte::5] |= ((data[:, 4::5] >> (byte * 2)) & 0b11)
+    data[:, byte::5] |= ((data[:, 4::5] >> ((byte + 1) * 2)) & 0b11)
 data = np.delete(data, np.s_[4::5], 1)
 
 # Now to split the data up into its red, green, and blue components. The


### PR DESCRIPTION
The current example does not work properly, this change should fix it. The array is bitshfted <<2 first, so this needs to be corrected for when reading reading the 2 LSBs.