### PR TITLE
allow bayer-denoise ISP block to be disabled

### DIFF
--- a/picamera/camera.py
+++ b/picamera/camera.py
@@ -337,6 +337,7 @@ class PiCamera(object):
         'white-balance': 1 << 5,
         'bad-pixel':     1 << 7,
         'crosstalk':     1 << 9,
+        'bayer_denoise': 1 << 10,
         'demosaic':      1 << 11,
         'gamma':         1 << 18,
         'sharpening':    1 << 22,


### PR DESCRIPTION
The PiCamera can be used as a low-cost and widely accessible entropy source for RNG (random number generation) by calibrating camera settings to maximize noise. Previously, developers could only disable the secondary YUV420 de-noise algorithms.

Per #565 `'bayer_denoise': 1 << 10` can be added to the `ISP_BLOCKS` object so that it can be disabled via the PiCamera `isp_blocks` parameter. 

To address the concerns from @6by9 about disrupting the image processing pipeline, disabling the Bayer de-noise ISP block would not stall it because image format is preserved, similar to the YUV420 de-noise algorithm.