### PR TITLE
Use small preview buffer for HQ camera, with default amount of GPU RAM (76MB)

### DIFF
--- a/picamera/camera.py
+++ b/picamera/camera.py
@@ -2305,8 +2305,8 @@ class PiCamera(object):
             cc.stills_yuv422 = 0
             cc.one_shot_stills = 1
             if small_preview:
-                cc.max_preview_video_w = 1920
-                cc.max_preview_video_h = 1080
+                cc.max_preview_video_w = 320
+                cc.max_preview_video_h = 240
             else:
                 cc.max_preview_video_w = new.resolution.width
                 cc.max_preview_video_h = new.resolution.height
@@ -2316,7 +2316,7 @@ class PiCamera(object):
             cc.use_stc_timestamp = new.clock_mode
             self._camera.control.params[mmal.MMAL_PARAMETER_CAMERA_CONFIG] = cc
             if small_preview:
-                preview_resolution = mo.to_resolution((1920,1080))
+                preview_resolution = mo.to_resolution((320,240))
 
             # Clamp preview resolution to camera's resolution
             if (

--- a/picamera/camera.py
+++ b/picamera/camera.py
@@ -2232,7 +2232,7 @@ class PiCamera(object):
             colorspace=self._camera.outputs[0].colorspace
         )
 
-    def _configure_camera(self, old, new):
+    def _configure_camera(self, old, new, small_preview=False):
         """
         An internal method for setting a new camera mode, framerate,
         resolution, clock_mode, and/or ISP blocks.
@@ -2304,13 +2304,19 @@ class PiCamera(object):
             cc.max_stills_h = new.resolution.height
             cc.stills_yuv422 = 0
             cc.one_shot_stills = 1
-            cc.max_preview_video_w = new.resolution.width
-            cc.max_preview_video_h = new.resolution.height
+            if small_preview:
+                cc.max_preview_video_w = 1920
+                cc.max_preview_video_h = 1080
+            else:
+                cc.max_preview_video_w = new.resolution.width
+                cc.max_preview_video_h = new.resolution.height
             cc.num_preview_video_frames = max(3, fps_high // 10)
             cc.stills_capture_circular_buffer_height = 0
             cc.fast_preview_resume = 0
             cc.use_stc_timestamp = new.clock_mode
             self._camera.control.params[mmal.MMAL_PARAMETER_CAMERA_CONFIG] = cc
+            if small_preview:
+                preview_resolution = mo.to_resolution((1920,1080))
 
             # Clamp preview resolution to camera's resolution
             if (
@@ -2613,9 +2619,14 @@ class PiCamera(object):
                     "Invalid resolution requested: %r" % (value,))
         config = self._get_config()
         self._disable_camera()
-        self._configure_camera(config, config._replace(resolution=value))
-        self._configure_splitter()
-        self._enable_camera()
+        try:
+            self._configure_camera(config, config._replace(resolution=value))
+            self._configure_splitter()
+            self._enable_camera()
+        except PiCameraMMALError:
+            self._configure_camera(config, config._replace(resolution=value), small_preview=True)
+            self._configure_splitter()
+            self._enable_camera()
     resolution = property(_get_resolution, _set_resolution, doc="""
         Retrieves or sets the resolution at which image captures, video
         recordings, and previews will be captured.


### PR DESCRIPTION
With the HQ camera I found to get picamera to take a photo with the default amount of GPU RAM (76MB) I had to set the preview buffer size to around 320x240, so that it would not run out of resources.

This pull request attempts first to use the maximum preview buffer, if this fails it tries again with 320x240 sized preview buffers.

In the process of switching to the smaller preview buffer size, I note the following message is printed:

```
mmal: mmal_vc_component_enable: failed to enable component: ENOSPC
````

I am wondering if it may be possible to hide this too?

I found from - https://github.com/waveform80/picamera/issues/627#issuecomment-631394933 that raspistill uses 1080p max preview buffer size.  I had to use 320x240 rather than 1080p though.  I'm wondering if there may be any downsides to using 320x240 as the preview buffer size?