### PR TITLE
Fix MMal no buffers available.

### DIFF
--- a/picamera/mmalobj.py
+++ b/picamera/mmalobj.py
@@ -1289,7 +1289,11 @@ class MMALPort(MMALControlPort):
             finally:
                 buf.release()
                 try:
-                    self._pool.send_buffer(block=False)
+                    # Only try to send buffer if the port type is output
+                    # or else we will suffer a MMAL no buffers available
+                    # error.
+                    if self._port[0].type == mmal.MMAL_PORT_TYPE_OUTPUT:
+                        self._pool.send_buffer(block=False)
                 except PiCameraPortDisabled:
                     # The port was disabled, no point trying again
                     pass


### PR DESCRIPTION
This fixes `picamera.exc.PiCameraMMALError: no buffers available: Resource temporarily unavailable` when dealing with raw mmalobj and overlays.

What seems to happen is that we try to send buffers _all the time_ instead of only doing it on port that is an output. This fixes it for me and I have not seen any issues as a result.

Let me know if this is good enough for inclusion or if you want me to do additional digging.

(For some reason I was not able to monkeypatch this from my code, probably because my python is somewhat limited) 